### PR TITLE
Добавлена фильтрация популярных фильмов по жанру и году

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -43,10 +43,13 @@ public class FilmController {
     }
 
     @GetMapping("/popular")
-    public Collection<FilmDto> getPopularFilms(@RequestParam(defaultValue = "10") @Min(0) Integer count) {
-        log.info("Получен HTTP-запрос на получение {} самых популярных фильмов", count);
-        Collection<FilmDto> popularFilms = filmService.getPopularFilms(count);
-        log.info("Успешно обработан HTTP-запрос на получение {} самых популярных фильмов", count);
+    public Collection<FilmDto> getPopularFilms(
+            @RequestParam(defaultValue = "10") @Min(0) Integer count,
+            @RequestParam(required = false) Integer genreId,
+            @RequestParam(required = false) Integer year) {
+        log.info("Получен HTTP-запрос на получение популярных фильмов: count={}, genreId={}, year={}", count, genreId, year);
+        Collection<FilmDto> popularFilms = filmService.getPopularFilms(count, genreId, year);
+        log.info("Успешно обработан HTTP-запрос на получение популярных фильмов: count={}, genreId={}, year={}", count, genreId, year);
         return popularFilms;
     }
 

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -100,12 +100,11 @@ public class FilmService {
         filmStorage.deleteLike(id, userId);
     }
 
-    public List<FilmDto> getPopularFilms(Integer count) {
-        // старый метод вызывает новый, передавая null-фильтры
-        return getPopularFilms(count, null, null);
-    }
-
     public List<FilmDto> getPopularFilms(Integer count, Integer genreId, Integer year) {
+        if (genreId != null) {
+            genreStorage.getGenreById(genreId);
+        }
+
         List<Film> films = filmStorage.getPopularFilms(count, genreId, year);
         return films.stream()
                 .map(FilmMapper::convertToDto)

--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -101,14 +101,15 @@ public class FilmService {
     }
 
     public List<FilmDto> getPopularFilms(Integer count) {
-        List<Film> films = filmStorage.getPopularFilms(count);
-        List<FilmDto> dtoList = new ArrayList<>();
-        if (films != null) {
-            dtoList = films.stream()
-                    .map(FilmMapper::convertToDto)
-                    .toList();
-        }
-        return dtoList;
+        // старый метод вызывает новый, передавая null-фильтры
+        return getPopularFilms(count, null, null);
+    }
+
+    public List<FilmDto> getPopularFilms(Integer count, Integer genreId, Integer year) {
+        List<Film> films = filmStorage.getPopularFilms(count, genreId, year);
+        return films.stream()
+                .map(FilmMapper::convertToDto)
+                .toList();
     }
 
     public FilmDto getFilmById(Long id) {

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
@@ -16,6 +16,7 @@ import ru.yandex.practicum.filmorate.storage.film.mapper.FilmExtractor;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -102,6 +103,29 @@ public class FilmDbStorage implements FilmStorage {
             "  WHERE ful2.user_id = ?" +
             ") " +
             "ORDER BY (SELECT COUNT(*) FROM film_user_like WHERE film_id = f.id) DESC";
+
+    private static final String FIND_POPULAR_WITH_FILTERS =
+            "SELECT f.id, f.name, f.description, f.release_date, f.duration, f.rating_id, " +
+                    "r.name AS rating_name, COALESCE(l.like_count, 0) AS like_count, " +
+                    "g.genre_id, g.genre_name, d.director_id, d.director_name " +
+                    "FROM films f " +
+                    "JOIN rating r ON f.rating_id = r.id " +
+                    "LEFT JOIN (" +
+                    "    SELECT film_id, COUNT(user_id) AS like_count " +
+                    "    FROM film_user_like " +
+                    "    GROUP BY film_id" +
+                    ") l ON f.id = l.film_id " +
+                    "LEFT JOIN (" +
+                    "    SELECT fg.film_id, g.id AS genre_id, g.name AS genre_name " +
+                    "    FROM film_genre fg " +
+                    "    JOIN genres g ON fg.genre_id = g.id" +
+                    ") g ON g.film_id = f.id " +
+                    "LEFT JOIN (" +
+                    "    SELECT fd.film_id, d.id AS director_id, d.name AS director_name " +
+                    "    FROM film_director fd " +
+                    "    JOIN directors d ON fd.director_id = d.id" +
+                    ") d ON d.film_id = f.id " +
+                    "WHERE 1=1 ";
 
     private final JdbcTemplate jdbc;
     private final FilmExtractor filmExtractor;
@@ -192,8 +216,25 @@ public class FilmDbStorage implements FilmStorage {
     }
 
     @Override
-    public List<Film> getPopularFilms(Integer count) {
-        return jdbc.query(FIND_MOST_POPULAR, filmExtractor, count);
+    public List<Film> getPopularFilms(Integer count, Integer genreId, Integer year) {
+        StringBuilder sql = new StringBuilder(FIND_POPULAR_WITH_FILTERS);
+        List<Object> params = new ArrayList<>();
+
+        if (genreId != null) {
+            sql.append("AND f.id IN (SELECT film_id FROM film_genre WHERE genre_id = ?) ");
+            params.add(genreId);
+        }
+
+        if (year != null) {
+            sql.append("AND EXTRACT(YEAR FROM f.release_date) = ? ");
+            params.add(year);
+        }
+
+        sql.append("ORDER BY COALESCE(l.like_count, 0) DESC ");
+        sql.append("LIMIT ?");
+        params.add(count);
+
+        return jdbc.query(sql.toString(), filmExtractor, params.toArray());
     }
 
     @Override

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
@@ -54,17 +54,6 @@ public class FilmDbStorage implements FilmStorage {
     private static final String INSERT_LIKE = "MERGE INTO film_user_like KEY(film_id, user_id) VALUES (?, ?)";
     private static final String DELETE_LIKE = "DELETE FROM film_user_like WHERE film_id = ? AND user_id = ?";
 
-    private static final String FIND_MOST_POPULAR = "SELECT f.*, r.name rating_name, g.genre_name, g.genre_id, " +
-            "directors.director_id, directors.director_name, likes.like_count " +
-            "FROM films f JOIN rating r ON f.rating_id = r.id " +
-            "LEFT JOIN (SELECT fg.*, g.name genre_name FROM film_genre fg " +
-            "JOIN genres g ON fg.genre_id = g.id) g ON g.film_id = f.id " +
-            "RIGHT JOIN (SELECT f.id, l.like_count FROM films f " +
-            "LEFT JOIN (SELECT film_id, COUNT(user_id) AS like_count " +
-            "FROM film_user_like GROUP BY film_id) AS l ON f.id = l.film_id " +
-            "ORDER BY l.like_count DESC LIMIT ?) likes ON likes.id = f.id " +
-            "LEFT JOIN (SELECT fd.*, d.name director_name FROM film_director fd " +
-            "JOIN directors d ON fd.director_id = d.id) directors ON directors.film_id = f.id";
     private static final String FIND_DIRECTOR_FILMS_SORTED_BY_YEAR = "SELECT f.*, r.name rating_name, g.genre_name, g.genre_id, " +
             "directors.director_id, directors.director_name " +
             "FROM films f " +
@@ -74,6 +63,7 @@ public class FilmDbStorage implements FilmStorage {
             "RIGHT JOIN (SELECT fd.*, d.name director_name FROM film_director fd " +
             "JOIN directors d ON fd.director_id = d.id WHERE d.id = ?) directors ON directors.film_id = f.id " +
             "ORDER BY f.release_date";
+
     private static final String FIND_DIRECTOR_FILMS_SORTED_BY_LIKES = "SELECT f.*, r.name rating_name, g.genre_name, " +
             "g.genre_id, directors.director_id, directors.director_name " +
             "FROM films f " +
@@ -221,7 +211,7 @@ public class FilmDbStorage implements FilmStorage {
         List<Object> params = new ArrayList<>();
 
         if (genreId != null) {
-            sql.append("AND f.id IN (SELECT film_id FROM film_genre WHERE genre_id = ?) ");
+            sql.append("AND g.genre_id = ? ");
             params.add(genreId);
         }
 

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
@@ -17,7 +17,7 @@ public interface FilmStorage {
 
     void deleteLike(Long id, Long userId);
 
-    List<Film> getPopularFilms(Integer count);
+    List<Film> getPopularFilms(Integer count, Integer genreId, Integer year);
 
     Film getFilmById(Long id);
 


### PR DESCRIPTION
Добавлен эндпоинт: `GET /films/popular?count={limit}&genreId={genreId}&year={year}`
Поддерживается фильтрация популярных фильмов по жанру (`genreId`) и году (`year`)
Реализован SQL-запрос с агрегацией лайков и подгрузкой жанров/режиссёров через подзапросы
Поддержка сортировки по количеству лайков
Совместимость с FilmExtractor сохранена
Все Postman-тесты (181) успешно пройдены ✅